### PR TITLE
use dart pub command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=protobuf /protoc/include /usr/local/include
 COPY --from=protobuf /protoc/readme.txt /protoc-readme.txt
 
 ENV PATH="/root/.pub-cache/bin:$PATH"
-RUN pub global activate protoc_plugin $PROTOC_PLUGIN_VERSION
+RUN dart pub global activate protoc_plugin $PROTOC_PLUGIN_VERSION
 
 COPY README.md /README.md
 WORKDIR /project


### PR DESCRIPTION
For some reason, the pub command can no longer be used directly in the latest dart image. The docker file now uses "dart pub"